### PR TITLE
improve finding wireless hardware

### DIFF
--- a/usr/bin/occi
+++ b/usr/bin/occi
@@ -211,7 +211,7 @@ sub handle_wifi {
 
   diag('Configuring network :: ' . $config{wifi_ssid});
 
-  my ($ifconfig) = capture_string('ifconfig', '-s');
+  my ($ifconfig) = capture_string('ifconfig', '-a');
   if ($ifconfig !~ /wlan/) {
     diag('No wireless hardware found.');
   } elsif (defined $config{wifi_password}) {
@@ -348,7 +348,7 @@ sub get_file {
 
   local $/ = undef;
   open my $fh, '<', $path
-    or die "Failed opening $path: $!"; 
+    or die "Failed opening $path: $!";
   my $contents = <$fh>;
   close $fh;
 
@@ -375,7 +375,7 @@ sub put_file {
   }
 
   open my $fh, '>', $path
-    or die "Failed opening $path: $!"; 
+    or die "Failed opening $path: $!";
   print $fh $content;
   close $fh;
 }


### PR DESCRIPTION
Thank you for this tiny little helper. I have a little improvement for
it finding the wireless hardware more reliable.

In my case my Edimax USB WiFi dongle didn't showed up calling ifconfig -s

```
$ ifconfig -s
Iface   MTU Met   RX-OK RX-ERR RX-DRP RX-OVR    TX-OK TX-ERR TX-DRP TX-OVR Flg
eth0       1500 0       641      0      0 0           204      0      0      0 BMRU
lo        65536 0         8      0      0 0             8      0      0      0 LRU
```

But with `ifconfig -a` the device was shown and then `occi` activated the WiFi config correctly.

```
$ ifconfig -a
eth0      Link encap:Ethernet  HWaddr b8:27:eb:xx:xx:xx  
          inet addr:192.168.x.x  Bcast:192.168.x.xxx  Mask:255.255.255.0
          inet6 addr: fe80::ba27:xxxx:xxxx:xxxx/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:595 errors:0 dropped:0 overruns:0 frame:0
          TX packets:177 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:99946 (97.6 KiB)  TX bytes:23209 (22.6 KiB)

lo        Link encap:Local Loopback  
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:8 errors:0 dropped:0 overruns:0 frame:0
          TX packets:8 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0 
          RX bytes:1104 (1.0 KiB)  TX bytes:1104 (1.0 KiB)

wlan0     Link encap:Ethernet  HWaddr 74:da:38:xx:xx:xx  
          UP BROADCAST MULTICAST  MTU:1500  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
```
