### PR TITLE
Quote wifi_ssid to allow spaces in SSID

### DIFF
--- a/usr/bin/occi
+++ b/usr/bin/occi
@@ -217,7 +217,7 @@ sub handle_wifi {
   } elsif (defined $config{wifi_password}) {
     my $wpa_config = capture_string(
       'wpa_passphrase',
-      $config{wifi_ssid},
+      $config{'wifi_ssid'},
       $config{'wifi_password'}
     );
 


### PR DESCRIPTION
When an SSID contains a space, wpa_passphrase returns an incorrect hash and the Pi is not able to connect to the WLAN. Quoting the SSID in the call to wpa_passphrase solves the issue.
